### PR TITLE
Add triggers and triggeredBy to job model

### DIFF
--- a/model/job.js
+++ b/model/job.js
@@ -1,6 +1,8 @@
 'use strict';
 const Joi = require('joi');
 const mutate = require('../lib/mutate');
+// For example, '155' or '155:staging'
+const jobPattern = new RegExp(/^([0-9]+)(:[\w-]+)?$/);
 
 const MODEL = {
     id: Joi
@@ -25,7 +27,21 @@ const MODEL = {
         ])
         .description('Current state of the Job')
         .example('ENABLED')
-        .default('ENABLED')
+        .default('ENABLED'),
+
+    triggers: Joi
+        .array()
+        .items(Joi.string().regex(jobPattern))
+        .description('Jobs that are triggered by this Job')
+        .example(['155:staging', '264:production'])
+        .default([]),
+
+    triggeredBy: Joi
+        .array()
+        .items(Joi.string().regex(jobPattern))
+        .description('Jobs that trigger this Job')
+        .example(['948:staging', '264'])
+        .default([])
 };
 
 module.exports = {
@@ -44,6 +60,6 @@ module.exports = {
      * @return {Joi} Joi Object
      */
     get: Joi.object(mutate(MODEL, [
-        'id', 'pipelineId', 'name', 'state'
+        'id', 'pipelineId', 'name', 'state', 'triggers', 'triggeredBy'
     ], [])).label('Get Job')
 };

--- a/test/data/job.get.yaml
+++ b/test/data/job.get.yaml
@@ -3,3 +3,5 @@ id: 30052
 name: 'component'
 pipelineId: 324
 state: 'ENABLED'
+triggers: ['123456', '155:staging']
+triggeredBy: ['948']

--- a/test/data/job.yaml
+++ b/test/data/job.yaml
@@ -3,3 +3,5 @@ id: 30052
 name: 'component'
 pipelineId: 324
 state: 'ENABLED'
+triggers: ['123456', '155:staging']
+triggeredBy: ['948']


### PR DESCRIPTION
- `triggers` is an array of jobs that are triggered by the current job
- `triggeredBy` is an array of jobs that trigger the current job

Adding to address issue https://github.com/screwdriver-cd/data-model/issues/4