### PR TITLE
Pipeline model id is a hex string

### DIFF
--- a/model/pipeline.js
+++ b/model/pipeline.js
@@ -4,9 +4,9 @@ const mutate = require('../lib/mutate');
 
 const MODEL = {
     id: Joi
-        .number().positive()
+        .string().hex().length(40)
         .description('Identifier of this Pipeline')
-        .example(16695),
+        .example('2d991790bab1ac8576097ca87f170df73410b55c'),
 
     platform: Joi
         .string()

--- a/test/data/pipeline.get.yaml
+++ b/test/data/pipeline.get.yaml
@@ -1,5 +1,5 @@
 # Pipeline Get Example
-id: 16695
+id: 2d991790bab1ac8576097ca87f170df73410b55c
 platform: nodejs_app@4
 scmUrl: git@github.com:screwdriver-cd/data-model.git#master
 createTime: 2017-04-11

--- a/test/data/pipeline.yaml
+++ b/test/data/pipeline.yaml
@@ -1,5 +1,5 @@
 # Pipeline Example
-id: 16695
+id: 2d991790bab1ac8576097ca87f170df73410b55c
 platform: nodejs_app@4
 scmUrl: git@github.com:screwdriver-cd/data-model.git#master
 configUrl: git@github.com:screwdriver-cd/external-config.git#master


### PR DESCRIPTION
In conjunction with PR screwdriver-cd/plugin-pipelines#5

This is to ensure the model also validates the ID is a hex string