### PR TITLE
Convert jobId and pipelineId to string

### DIFF
--- a/model/build.js
+++ b/model/build.js
@@ -9,9 +9,9 @@ const MODEL = {
         .example('4b8d9b530d2e5e297b4f470d5b0a6e1310d29c5e'),
 
     jobId: Joi
-        .number().positive()
+        .string().hex().length(40)
         .description('Identifier of the Job')
-        .example(30052),
+        .example('50dc14f719cdc2c9cb1fb0e49dd2acc4cf6189a0'),
 
     runNumber: Joi
         .number().positive()

--- a/model/job.js
+++ b/model/job.js
@@ -16,9 +16,9 @@ const MODEL = {
         .example('component'),
 
     pipelineId: Joi
-        .number().positive()
+        .string().hex().length(40)
         .description('Identifier of the Pipeline')
-        .example(324),
+        .example('2d991790bab1ac8576097ca87f170df73410b55c'),
 
     state: Joi
         .string().valid([

--- a/test/data/build.create.yaml
+++ b/test/data/build.create.yaml
@@ -1,3 +1,3 @@
 # Build Create Example
-jobId: 30052
+jobId: 50dc14f719cdc2c9cb1fb0e49dd2acc4cf6189a0
 container: node:4

--- a/test/data/build.get.yaml
+++ b/test/data/build.get.yaml
@@ -1,6 +1,6 @@
 # Build Get Example
 id: 4b8d9b530d2e5e297b4f470d5b0a6e1310d29c5e
-jobId: 30052
+jobId: 50dc14f719cdc2c9cb1fb0e49dd2acc4cf6189a0
 runNumber: 15
 container: node:4
 cause: Commit ccc493 was pushed to master

--- a/test/data/build.yaml
+++ b/test/data/build.yaml
@@ -1,4 +1,4 @@
 # Build Example
-jobId: 30052
+jobId: 50dc14f719cdc2c9cb1fb0e49dd2acc4cf6189a0
 runNumber: 15
 container: node:4

--- a/test/data/job.get.yaml
+++ b/test/data/job.get.yaml
@@ -1,7 +1,7 @@
 # Job Get Example
 id: 50dc14f719cdc2c9cb1fb0e49dd2acc4cf6189a0
 name: component
-pipelineId: 324
+pipelineId: 2d991790bab1ac8576097ca87f170df73410b55c
 state: ENABLED
 triggers: ['123456', '155:staging']
 triggeredBy: ['948']

--- a/test/data/job.yaml
+++ b/test/data/job.yaml
@@ -1,7 +1,7 @@
 # Job Example
 id: 50dc14f719cdc2c9cb1fb0e49dd2acc4cf6189a0
 name: component
-pipelineId: 324
+pipelineId: 2d991790bab1ac8576097ca87f170df73410b55c
 state: ENABLED
 triggers: ['123456', '155:staging']
 triggeredBy: ['948']


### PR DESCRIPTION
Since all `id` should be a string now, changing `jobId` and `pipelineId` to conform as well